### PR TITLE
Fix deprecations for new dbt engine compatibility

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,6 +28,6 @@ vars:
 models:
   recurly_source:
     +schema: recurly_source
-    materialized: table
+    +materialized: table
     tmp:
-      materialized: view
+      +materialized: view

--- a/models/stg_recurly.yml
+++ b/models/stg_recurly.yml
@@ -346,7 +346,6 @@ models:
       - name: is_most_recent_record
         description: Is this the most recent record of this invoice?
       - name: net_terms
-        description: Terms of subscription.
         description: >
           Integer representing the number of days after an invoice's creation that the invoice will become past due. 
           If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. 


### PR DESCRIPTION
This is a PR raised to fix [dbt config deprecations](https://github.com/dbt-labs/dbt-core/discussions/11493) currently in the package and improve compatibility with the new dbt engine being released on 5/28 at the dbt Launch Showcase.

Ideally, this PR would need to be merged and a new version of the package should be published to the Hub before 5/28.

Please comment on this PR if you have any question.